### PR TITLE
Explicit Files & Preload type

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Add version number to js/css/image in HTML
                     'attr'  : ['src', 'custom-src'] // String or Array, undefined this will use default. css: "href", js: ...
                     'key'   : '_v',
                     'value' : '%DATE%',
-                    'cover' : 1
+                    'cover' : 1,
+                    'files': ['build.js', /dependency.js/] // Array [{String|Regex}] of explicit files to append to
                 }
             ]
         },

--- a/index.js
+++ b/index.js
@@ -166,8 +166,6 @@ module.exports = function (options) {
     }
 
     function apply_append(content, config) {
-        console.log(config);
-
         var apList = [];
         if (config['to']) {
             if (config.to === 'all') {

--- a/index.js
+++ b/index.js
@@ -111,11 +111,13 @@ function version(v) {
 var DETECTION = {
     css  : /<link[^>]*rel=['"]?stylesheet['"]?[^>]*>/g,
     js   : /<script [^>]+>[^<]*<\/script>/g,
-    image: /<img [^>]+>/g
+    image: /<img [^>]+>/g,
+    preload: /<link[^>]*rel=['"]?preload['"]?[^>]*>/g
 };
 
 var DEFAULT_ATTR = {
     css  : 'href',
+    preload  : 'href',
     js   : 'src',
     image: 'src'
 }
@@ -164,6 +166,7 @@ module.exports = function (options) {
     }
 
     function apply_append(content, config) {
+        console.log(config);
 
         var apList = [];
         if (config['to']) {
@@ -216,6 +219,29 @@ module.exports = function (options) {
     function appendto(content, k, v) {
         this.attr = this['attr'] ? [].concat(this.attr) : [DEFAULT_ATTR[this.type]];
         var sts = content.match(DETECTION[this.type]);
+
+        if (Array.isArray(sts) && sts.length && this['files']) {
+            var files = this.files;
+            
+            sts = sts.filter(function(element) {
+                for (var i = 0; i < files.length; i++) {
+                    var file = files[i];
+
+                    if (typeof file == 'string') {
+                        if (element.indexOf(file) > -1) {
+                            return true;
+                        }
+                    } else if (file instanceof RegExp) {
+                        if (element.match(file)) {
+                            return true;
+                        }
+                    }
+                }
+                
+                return false;
+            });
+        }
+
         if (Array.isArray(sts) && sts.length) {
             var regExp = new RegExp('(' + this.attr.join('|') + ')' + '=[\'"]?([^>\'"]*)[\'"]?', 'g');
             sts.forEach(function (_s) {


### PR DESCRIPTION
# Explicit Files & Preload type


## Explicit Files
In its current state, gulp-version-number adds version numbers to **_all_** elements of the same type. This means that even external dependencies, or dependencies hosted on CDN's are all captured and appended a version number.

This can lead to unintended consequences, such as conflicting query variables, or cache-busting of CDN hosted dependencies that are not affected by our build process.

This PR introduces the ability to explicitly define files you wish target. Using the `Object` configuration for a type, you can add an array of files in the form of strings or regexps.

eg:

``` js
var versionConfig = {
  'value': '%MDS%',
  'append': {
    'cover': 1,
    'key': 'v',
    'to': [
      {
        'type': 'css',
        'files': ['application.css']
      },
      {
        'type': 'js',
        'files': ['application.js']
      },
      {
        'type'  : 'preload',
        'attr'  : ['href'],
        'files': ['application.js', 'application.css']
      }
    ],
  },
}
```

## Preload type
Preloading of assets is increasingly becoming the standard, a preloaded element is defined as a `link` element with `ref="preload"`. In order for preloaded assets to work as intended the preload `href` needs to match the asset `href`.

 i.e. :
```
Not correct:
<link rel="preload" href="/js/application.js" as="script">
<script src="/js/application.js?v=1497c75251306822999749513c13e01c"></script>

Correct:
<link rel="preload" href="/js/application.js?v=1497c75251306822999749513c13e01c" as="script">
<script src="/js/application.js?v=1497c75251306822999749513c13e01c"></script>
```

By adding the `preload` type we can make sure `preload` links and assets match correctly