### PR TITLE
Use native fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Add version number to js/css/image in HTML
 **config**
 
     {
-    
+
         /**
          * Global version value
          * default: %MDS%
          */
         'value' : '%MDS%',
-    
+
         /**
          * MODE: REPLACE
          * eg:
@@ -34,32 +34,32 @@ Add version number to js/css/image in HTML
          *    [/regexp/ig, '%MD5%']]
          */
         'replaces' : [
-        
+
             /**
              * {String|Regexp} Replace Keyword/Rules to global value (config.value)
              */
             '#{VERSION_REPlACE}#',
-            
+
             /**
              * {Array}
              * Replace keyword to custom value
              * if just have keyword, the value will use the global value (config.value).
-             */    
+             */
             [/#{VERSION_REPlACE}#/g, '%TS%']
         ],
-        
-        
+
+
         /**
          * MODE: APPEND
          * Can coexist and replace, after execution to replace
          */
         'append' : {
-        
+
             /**
              * Parameter
              */
             'key' : '_v',
-            
+
             /**
              * Whether to overwrite the existing parameters
              * default: 0 (don't overwrite)
@@ -67,14 +67,14 @@ Add version number to js/css/image in HTML
              * If you need to cover, please set to 1
              */
             'cover' : 0,
-            
+
             /**
              * Appended to the position (specify type)
              * {String|Array|Object}
              * If you set to 'all', will apply to all type, rules will use the global setting.
              * If an array or object, will use your custom rules.
              * others will passing.
-             * 
+             *
              * eg:
              *     'js'
              *     ['js']
@@ -82,28 +82,28 @@ Add version number to js/css/image in HTML
              *     ['css', '%DATE%']
              */
             'to' : [
-            
+
                 /**
                  * {String} Specify type, the value is the global value
                  */
                 'css',
-                
+
                 /**
                  * {Array}
-                 * Specify type, keyword and cover rules will use the global 
-                 * setting, If you need more details, please use the object 
+                 * Specify type, keyword and cover rules will use the global
+                 * setting, If you need more details, please use the object
                  * configure.
                  *
                  * argument 0 necessary, otherwise passing.
                  * argument 1 optional, the value will use the global value
                  */
                   ['image', '%TS%'],
-                  
+
                 /**
                  * {Object}
-                 * Use detailed custom rules to replace, missing items will 
+                 * Use detailed custom rules to replace, missing items will
                  * be taken in setting the global completion
-                 
+
                  * type is necessary, otherwise passing.
                  */
                 {
@@ -116,7 +116,7 @@ Add version number to js/css/image in HTML
                 }
             ]
         },
-     
+
         /**
          * Output to config file
          */
@@ -148,6 +148,10 @@ Add version number to js/css/image in HTML
 
 
 ## Change log ##
+
+#### = 0.3.0 = ####
+- Drop fsPath dependency, due to having a known security issue.
+- Replace fsPath with native fs functions
 
 ##### = 0.2.0 = #####
 - Add a configure prop to "Object" model at "options.append.to", set the attribute what you want to match

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/shinate/gulp-version-number/",
   "repository": "https://github.com/shinate/gulp-version-number.git",
   "engines": {
-    "node": ">= 0.9"
+    "node": ">= 12"
   },
   "keywords": [
     "gulp",
@@ -23,7 +23,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "fs-path": "^0.0.24",
     "map-stream": "^0.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-version-number",
   "description": "Add version number to css/js/image... in HTML file.",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "author": "Shinate <shine.wangrs@gmail.com>",
   "bugs": {
     "url": "https://github.com/shinate/gulp-version-number/issues"


### PR DESCRIPTION
- [x] Drop fsPath and use native node fs functions
- [x] Update change log and bump as minor release

fsPath has a known vulnerability and had no updates from a long time. This PR will revert the dependency added to fix recursive writes while updating the call with the native functions.

Note that this requires a node version > 11.5 where these asynchronous  functions where introduced. Set as >=12 to use the LTS versions.

I don't think this breaks backward compatibility but does require a newer version of node.

### Testing

I ran the existing tests and it worked. I didn't expect the image to have a different md5, but there wasn't actually a image to start.

On my own tests, it was successful in creating recursively many directories and replacing the target.
