### PR TITLE
Update gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "map-stream": "^0.0.7"
   },
   "devDependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^4.0.2"
   }
 }


### PR DESCRIPTION
gulp is used as dev dependency to run the tests. I had no issues running the tests with the newest version, using the latest gulp-cli version and node.

This removes the remaining vulnerabilities from this package. See #13.