### PR TITLE
The ampersand must be written as the HTML entity in HTML

### DIFF
--- a/_test/dist/all.html
+++ b/_test/dist/all.html
@@ -3,15 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <title>ALL</title>
-    <link rel="stylesheet" href="http://www.balabala.com/assets/css/index.css?_VeRsIoN_=15c01823e33a74fbd90ba5a811f7c774" custom-href="http://www.balabala.com/src/sass/main.sass?_VeRsIoN_=15c01823e33a74fbd90ba5a811f7c774"/>
+    <link rel="stylesheet" href="http://www.balabala.com/assets/css/index.css?_VeRsIoN_=b927d3f1bb0190169ca8de304a91a20e" custom-href="http://www.balabala.com/src/sass/main.sass?_VeRsIoN_=b927d3f1bb0190169ca8de304a91a20e"/>
+    <link rel="stylesheet" href="/foo.css?foo=bar&amp;_VeRsIoN_=b927d3f1bb0190169ca8de304a91a20e">
+    <link rel="stylesheet" href="/bar.css?foo=bar&amp;baz=buz&amp;_VeRsIoN_=b927d3f1bb0190169ca8de304a91a20e">
 </head>
 <body>
 <img>
 <img/>
 <img />
-<img src="c.png?_v=d419a8df28e61fe4a69e92490d4ccde0"/>
-<script src="http://www.balabala.com/assets/js/main.bundle.min.js" custom-src="http://www.balabala.com/src/js/main.js?_VeRsIoN_=1545277214636"></script>
-<script src="http://www.balabala.com/assets/js/ABC.bundle.min.js" node-js-loader="http://www.balabala.com/src/js/ABC.js?_VeRsIoN_=1545277214636"></script>
+<img src="c.png?_v=302dd67d927e69e237cece67c36ed5dc"/>
+<script src="http://www.balabala.com/assets/js/main.bundle.min.js" custom-src="http://www.balabala.com/src/js/main.js?_VeRsIoN_=1639687892640"></script>
+<script src="http://www.balabala.com/assets/js/ABC.bundle.min.js" node-js-loader="http://www.balabala.com/src/js/ABC.js?_VeRsIoN_=1639687892640"></script>
 <script>
     alert(1);
 </script>

--- a/_test/src/all.html
+++ b/_test/src/all.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <title>ALL</title>
     <link rel="stylesheet" href="http://www.balabala.com/assets/css/index.css" custom-href="http://www.balabala.com/src/sass/main.sass"/>
+    <link rel="stylesheet" href="/foo.css?foo=bar">
+    <link rel="stylesheet" href="/bar.css?foo=bar&amp;baz=buz">
 </head>
 <body>
 <img>

--- a/lib/jsonToQuery.js
+++ b/lib/jsonToQuery.js
@@ -29,7 +29,7 @@ module.exports = function(JSON, isEncode) {
         }
     }
     if (_Qstring.length) {
-        return _Qstring.join("&");
+        return _Qstring.join("&amp;");
     }
     return "";
 

--- a/lib/queryToJson.js
+++ b/lib/queryToJson.js
@@ -7,12 +7,12 @@
  * @return {String} querystring
  * @author Robin Young | yonglin@staff.sina.com.cn
  * @example
- * var q1 = 'a=1&b=2&c=3';
+ * var q1 = 'a=1&amp;b=2&amp;c=3';
  * STK.core.json.queryToJson(q1) === {'a':1,'b':2,'c':3};
  */
 var trim = require('./trim');
 module.exports = function(QS, isDecode) {
-    var _Qlist = trim(QS).split("&");
+    var _Qlist = trim(QS).split("&amp;");
     var _json = {};
     var _fData = function(data) {
         if (isDecode) {


### PR DESCRIPTION
The ampersand ("&") has a special meaning in HTML, and when it's used in
an URL query string, they must be written as `&amp;`. For example, this
is the correct format:

    <link rel="stylesheet" href="main.css?foo=bar&amp;baz=buz">

This is invalid:

    <link rel="stylesheet" href="main.css?foo=bar&baz=buz">

This updates the library to correctly use the HTML entity in URLs.